### PR TITLE
Update links to Roc

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,6 @@ This project works, but it's a mess of non idiomatic go code without tests.
 
 ## C++
 
-#### [Roc](https://roc-project.github.io/)
-- [Help Wanted](https://github.com/roc-project/roc/labels/help%20wanted)
-- [Contribution Guidelines](https://roc-project.github.io/roc/docs/development/contribution_guidelines.html)
+#### [Roc Toolkit](https://roc-streaming.org/)
+- [Help Wanted](https://github.com/roc-streaming/roc-toolkit/labels/help%20wanted)
+- [Contribution Guidelines](https://roc-streaming.org/toolkit/docs/development/contribution_guidelines.html)


### PR DESCRIPTION
"Roc" was renamed to "Roc Toolkit", this PR updates the name and links.

